### PR TITLE
feat: load ec2 agent key from mounted secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,8 @@ Set the `<pi-host>` placeholder in `casc/jenkins.yaml` (organization defaults to
 - `JENKINS_URL` — externally reachable base URL for the controller (e.g. `https://jenkins.example.com/`).
 - `APIFY_TOKEN_DEV` / `APIFY_TOKEN_PROD` — deployment credentials consumed by the shared library.
 - `DOCKER_GID` — host Docker group id (e.g. `$(getent group docker | cut -d: -f3)`) so the non-root `jenkins` user can access `/var/run/docker.sock`.
+- `AWS_EC2_AGENT_PRIVATE_KEY_FILE` — path inside the container pointing to the PEM file for the EC2 SSH agent (the compose file mounts `/opt/jenkins/secrets/jenkins_agent` to `/run/secrets/aws_ec2_agent_key`).
+
+The EC2 agent key should reside on the Docker host at `/opt/jenkins/secrets/jenkins_agent` (mode `600`). The compose file bind-mounts this file into the container and the CasC bundle references it via `directEntryFromFile`.
 
 Redeploying the stack will reconcile any manual Portainer edits with these declarative settings.

--- a/casc/jenkins.yaml
+++ b/casc/jenkins.yaml
@@ -82,7 +82,7 @@ credentials:
               description: "SSH key for AWS EC2 Jenkins agent"
               username: "ubuntu"
               privateKeySource:
-                directEntry: "${AWS_EC2_AGENT_PRIVATE_KEY}"
+                directEntryFromFile: "${AWS_EC2_AGENT_PRIVATE_KEY_FILE}"
 
 tool:
   git:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,11 @@ services:
       - GITHUB_TOKEN=${GITHUB_TOKEN}
       - APIFY_TOKEN_DEV=${APIFY_TOKEN_DEV}
       - APIFY_TOKEN_PROD=${APIFY_TOKEN_PROD}
+      - AWS_EC2_AGENT_PRIVATE_KEY_FILE=/run/secrets/aws_ec2_agent_key
     volumes:
       - jenkins_home:/var/jenkins_home
+      - ./casc:/usr/share/jenkins/ref/casc:ro
+      - /opt/jenkins/secrets/jenkins_agent:/run/secrets/aws_ec2_agent_key:ro
       - /var/run/docker.sock:/var/run/docker.sock
     group_add:
       - "${DOCKER_GID:-998}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to include a required environment variable for the EC2 agent private key.
  * Clarified key location, required permissions, and how the container consumes it via a mounted secret.
  * Integrated the new key-path details into deployment steps.

* **Chores**
  * Switched credentials to read the EC2 agent private key from a file instead of inline.
  * Configured the runtime to mount configuration and the key as read-only.
  * Added an environment variable to expose the in-container key path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->